### PR TITLE
Add Slack link

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -45,8 +45,12 @@
     <li>
       <a href="{{ site.brigade.slack-signup }}">
       <i class=icon-comment icon-white></i>
-      Our Slack Organization</a>
+      Join Our Slack Organization</a>
     </li>
-
+    <li>
+      <a href="{{ site.brigade.slack }}">
+      <i class=icon-comment icon-white></i>
+      Talk With Us On Slack</a> (Join first!)
+    </li>
   </ul>
 </li>


### PR DESCRIPTION
Make join link more obvious that it is for joining slack, and add link to slack to use after you've joined.
